### PR TITLE
AtomsBase v0.5 update

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AtomsBuilder"
 uuid = "f5cc8831-eeb7-4288-8d9f-d6c1ddb77004"
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/Project.toml
+++ b/Project.toml
@@ -11,13 +11,13 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-AtomsBase = "0.4"
+AtomsBase = "0.5"
 JSON = "0.21.4"
-LinearAlgebra = "1.9.0, 1.10.0"
-Random = "1.9.0, 1.10.0"
+LinearAlgebra = "1.9"
+Random = "1.9"
 StaticArrays = "1.9"
 Unitful = "1.19"
-julia = "1.9.0, 1.10.0"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,7 +20,7 @@ function _flexible_system(positions, elements, cell, pbc)
    bc = pbc isa Bool ? (pbc, pbc, pbc) : tuple(pbc...)
    bb = tuple([cell[i, :] for i = 1:3]...)
    return FlexibleSystem(atoms; 
-                         bounding_box = bb, 
+                         cell_vectors = bb, 
                          periodicity = bc)
 end
 
@@ -38,7 +38,7 @@ function set_positions(at::FlexibleSystem,
    particles = [ _set_position(at.particles[i], X[i])
                  for i in 1:length(at) ] 
    return FlexibleSystem(particles, 
-                         bounding_box = bounding_box(at), 
+                         cell_vectors = cell_vectors(at), 
                          periodicity = periodicity(at))
 end
 
@@ -48,7 +48,7 @@ function set_elements(at::FlexibleSystem, Z::AbstractVector)
    particles = [ Atom(Z[i], position(x), velocity(x))
                  for (i, x) in enumerate(at.particles) ]
    return FlexibleSystem(particles, 
-                         bounding_box = bounding_box(at), 
+                         cell_vectors = cell_vectors(at), 
                          periodicity = periodicity(at))
 end
 
@@ -72,7 +72,7 @@ at = bulk(:) * (3, 2, 4)
 ```
 """
 function Base.repeat(at::FlexibleSystem, n::NTuple{3})
-   c1, c2, c3 = bounding_box(at)
+   c1, c2, c3 = cell_vectors(at)
 
    particles = eltype(at.particles)[] 
    for a in CartesianIndices( (1:n[1], 1:n[2], 1:n[3]) )
@@ -85,7 +85,7 @@ function Base.repeat(at::FlexibleSystem, n::NTuple{3})
    end
 
    bb = (c1 * n[1], c2 * n[2], c3 * n[3])
-   return FlexibleSystem(particles; bounding_box = bb, 
+   return FlexibleSystem(particles; cell_vectors = bb, 
                            periodicity = periodicity(at))
 end
 
@@ -173,9 +173,9 @@ takes the union of two particle systems provided their cells are identical.
 """
 function union(sys1::FlexibleSystem, sys2::FlexibleSystem) 
    @assert periodicity(sys1) == periodicity(sys2)
-   @assert bounding_box(sys1) == bounding_box(sys2)
+   @assert cell_vectors(sys1) == cell_vectors(sys2)
    return FlexibleSystem(union(sys1.particles, sys2.particles),  
-                        bounding_box = bounding_box(at), 
+                        cell_vectors = cell_vectors(at), 
                         periodicit = periodicity(at) )
 end
 

--- a/test/test_bulk.jl
+++ b/test/test_bulk.jl
@@ -12,7 +12,7 @@ test_systems = JSON.parsefile(joinpath(@__DIR__(), "..", "data", "test_systems.j
 _ustripvecvec(X) = [ ustrip.(x) for x in X ]
 
 compare_system(sys_f, sys_j) = (
-      all( ustrip.( hcat(bounding_box(sys_f)...) ) .≈ hcat(sys_j["cell"]...)' )  && 
+      all( ustrip.( hcat(cell_vectors(sys_f)...) ) .≈ hcat(sys_j["cell"]...)' )  && 
       all( AtomsBuilder._convert_pbc(sys_j["pbc"]) .== periodicity(sys_f) ) && 
       all( atomic_number(sys_f, :) .== sys_j["Z"] ) && 
       all( _ustripvecvec(position(sys_f, :)) .≈ sys_j["X"] )    )


### PR DESCRIPTION
This update holds back following packages:

1. NeighbourLists.jl - (AtomsBuilder.jl needed for testing only or ASEconvert.jl which we should drop)
2. AtomsCalculatorsUtilities.jl - depends on NeighbourLists.jl
3. EmpiricalPotentials.jl - depends on AtomsCalculatorsUtilities.jl

Also ACEpotentials.jl depends on this update chain and probably some other packages.

I also added support for Julia v1.11, which works fine.