### PR TITLE
Get structures from Pubchem

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,8 +24,7 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - '1.9'
-          - 'nightly'
+          - '1'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ PubChemCrawler = "1.2"
 Random = "1.9"
 StaticArrays = "1.9"
 Unitful = "1.19"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -4,16 +4,20 @@ version = "0.2.2"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
+AtomsIO = "1692102d-eeb4-4df9-807b-c9517f998d44"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PubChemCrawler = "30e472fa-2b12-4c0b-9705-07d174b7a4e1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 AtomsBase = "0.5"
+AtomsIO = "0.3"
 JSON = "0.21.4"
 LinearAlgebra = "1.9"
+PubChemCrawler = "1.2"
 Random = "1.9"
 StaticArrays = "1.9"
 Unitful = "1.19"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package provides utilities to build atomic structures. At the moment the fu
 
 ## Preliminary Documentation 
 
-Currently there are just two exported functions: 
+Currently there are just two exported functions to build materials: 
 * `bulk`
 * `rattle!`
 In addition we overload 
@@ -39,6 +39,27 @@ at5 = rattle!( bulk(:Si, cubic=true) * 3 )
 ```
 
 See `?bulk` and `?rattle!` for more information. 
+
+## PubChem inteface
+
+PubChem interface allows you to download structures from [PubChem](https://pubchem.ncbi.nlm.nih.gov/).
+This is done with `load_from_pubchem` function. You can only load isolated molecules currently.
+
+```julia
+using AtomsBuilder
+
+# using trivial name
+load_from_pubchem( "water" )
+
+# using CID
+load_from_pubchem( 887 )
+
+# using SMILES
+load_from_pubchem( smiles="CC(=O)C" )
+
+# using CAS number
+load_from_pubchem( "64-17-5" )
+```
 
 ## Contributions 
 

--- a/src/AtomsBuilder.jl
+++ b/src/AtomsBuilder.jl
@@ -9,5 +9,6 @@ const Vec3{T} = SVector{3, T}
 include("chemistry.jl")
 include("utils.jl")
 include("bulk.jl")
+include("pubchem.jl")
 
 end

--- a/src/pubchem.jl
+++ b/src/pubchem.jl
@@ -1,0 +1,27 @@
+using AtomsBase: FastSystem
+using AtomsIO: load_system
+using PubChemCrawler: get_cid, get_for_cids 
+
+export load_from_pubchem
+
+
+function load_from_pubchem(cid::Int)
+    tmp_name = tempname() * ".sdf"
+    open(tmp_name, "w") do io
+        write(io, get_for_cids(cid, output="SDF", record_type="3d"))
+    end
+    # parsing system does not work properly so we drop global features
+    sys = FastSystem( load_system(tmp_name) )
+    rm(tmp_name)
+    return sys
+end
+
+function load_from_pubchem(name::AbstractString)
+    cid = get_cid(name=name)
+    return load_from_pubchem(cid)
+end
+
+function load_from_pubchem(;smiles::AbstractString)
+    cid = get_cid(smiles=smiles)
+    return load_from_pubchem(cid)
+end

--- a/src/pubchem.jl
+++ b/src/pubchem.jl
@@ -4,7 +4,33 @@ using PubChemCrawler: get_cid, get_for_cids
 
 export load_from_pubchem
 
+"""
+    load_from_pubchem(cid::Int)
+    load_from_pubchem(name::AbstractString)
+    load_from_pubchem(;smiles::AbstractString)
 
+Load a molecule from [PubChem](https://pubchem.ncbi.nlm.nih.gov/).
+
+You can use [PubChemCrawler](https://github.com/JuliaHealth/PubChemCrawler.jl)
+to search for `cid`.
+
+# Example
+```julia
+using AtomsBuilder
+
+# using trivial name
+load_from_pubchem( "water" )
+
+# using CID
+load_from_pubchem( 887 )
+
+# using SMILES
+load_from_pubchem( smiles="CC(=O)C" )
+
+# using CAS number
+load_from_pubchem( "64-17-5" )
+```
+"""
 function load_from_pubchem(cid::Int)
     tmp_name = tempname() * ".sdf"
     open(tmp_name, "w") do io

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Test
     # Write your tests here.
     @testset "bulk" begin include("test_bulk.jl"); end
     @testset "utils" begin include("test_utils.jl"); end
+    include("test_pubchem.jl")
 end
 
 

--- a/test/test_pubchem.jl
+++ b/test/test_pubchem.jl
@@ -1,0 +1,14 @@
+using AtomsBase
+using AtomsBuilder
+using Test
+
+@testset "PubChem inteface" begin
+    sys = load_from_pubchem( "water" )
+    @test length(sys) == 3
+    sys = load_from_pubchem( 887 ) # methanol
+    @test length(sys) == 6
+    sys = load_from_pubchem( smiles="CC(=O)C" ) # asetone
+    @test length(sys) == 10
+    sys = load_from_pubchem( "64-17-5" ) # ethanol
+    @test length(sys) == 9
+end


### PR DESCRIPTION
This PR adds a function to pull structures from [PubChem](https://pubchem.ncbi.nlm.nih.gov/).
It works for isolated molecules only.
[PubChemCrawler.jl](https://github.com/JuliaHealth/PubChemCrawler.jl) is used as a backend.

```julia
using AtomsBuilder

# using trivial name
load_from_pubchem( "water" )

# using CID
load_from_pubchem( 887 )

# using SMILES
load_from_pubchem( smiles="CC(=O)C" )

# using CAS number
load_from_pubchem( "64-17-5" )
```