### PR TITLE
Add Examples submodule (rocksalt, nacl, tip3p_water)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AtomsBuilder"
 uuid = "f5cc8831-eeb7-4288-8d9f-d6c1ddb77004"
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
@@ -11,6 +11,7 @@ PubChemCrawler = "30e472fa-2b12-4c0b-9705-07d174b7a4e1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
 AtomsBase = "0.5"
@@ -21,6 +22,7 @@ PubChemCrawler = "1.2"
 Random = "1.10"
 StaticArrays = "1.9"
 Unitful = "1.19"
+UnitfulAtomic = "1"
 julia = "1.10"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,38 @@ at5 = rattle!( bulk(:Si, cubic=true) * 3 )
 
 See `?bulk` and `?rattle!` for more information. 
 
+## `AtomsBuilder.Examples`
+
+The `Examples` submodule ships fixture systems that are useful for
+testing, benchmarking, and tuning downstream packages. The API may
+evolve — pin a version if you depend on it.
+
+* `rocksalt(species_a, species_b, n)` — 1:1 rock-salt supercell (NaCl
+  structure) with charges `±1 e_au` attached as a per-atom property.
+* `nacl(n)` — convenience alias for `rocksalt(:Na, :Cl, n)`.
+* `tip3p_water(box)` — cubic box of randomly-placed, randomly-oriented
+  TIP3P water molecules (Bridson Poisson-disk for O placement; charges
+  `q_O = -0.834 e_au`, `q_H = +0.417 e_au`).
+
+```julia
+using AtomsBuilder.Examples, Unitful, UnitfulAtomic
+
+# 64-ion NaCl supercell, perfect lattice
+sys = nacl(2)
+
+# 216-ion NaCl supercell, σ = 0.1 Å Gaussian displacements (~300 K thermal)
+sys = nacl(3; σ = 0.1u"Å", rng = Random.MersenneTwister(0))
+
+# ~58-molecule water box, default density (1 g/cm³), default d_min = 2.7 Å
+sys = tip3p_water(12.0u"Å")
+```
+
+Charges are stored on each `Atom` as a per-atom property under the
+keyword `:charge` by default (extracted via `atom.data[:charge]`).
+Pass `charge_label = :q` (or similar) to use a different key.
+
+See `?rocksalt`, `?nacl`, `?tip3p_water` for full options.
+
 ## PubChem Interface
 
 PubChem interface allows you to download structures from [PubChem](https://pubchem.ncbi.nlm.nih.gov/).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,16 @@ sys = tip3p_water(12.0u"Å")
 ```
 
 Charges are stored on each `Atom` as a per-atom property under the
-keyword `:charge` by default (extracted via `atom.data[:charge]`).
+keyword `:charge` by default — the property name reserved for net atom
+charge in the [AtomsBase tutorial](https://juliamolsim.github.io/AtomsBase.jl/stable/tutorial/).
+Extract with the standard AtomsBase dictionary-style access:
+
+```julia
+a = sys[1]
+a[:charge]            # 1.0 e_au
+haskey(a, :charge)    # true
+```
+
 Pass `charge_label = :q` (or similar) to use a different key.
 
 See `?rocksalt`, `?nacl`, `?tip3p_water` for full options.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,5 +10,5 @@ Documentation for [AtomsBuilder](https://github.com/JuliaMolSim/AtomsBuilder.jl)
 ```
 
 ```@autodocs
-Modules = [AtomsBuilder]
+Modules = [AtomsBuilder, AtomsBuilder.Examples]
 ```

--- a/src/AtomsBuilder.jl
+++ b/src/AtomsBuilder.jl
@@ -10,5 +10,6 @@ include("chemistry.jl")
 include("utils.jl")
 include("bulk.jl")
 include("pubchem.jl")
+include("examples/Examples.jl")
 
 end

--- a/src/examples/Examples.jl
+++ b/src/examples/Examples.jl
@@ -1,0 +1,44 @@
+"""
+    AtomsBuilder.Examples
+
+Staging area for builders of example / fixture systems that are
+useful to downstream packages for testing, benchmarking, and tuning.
+
+Currently exposes:
+
+- [`rocksalt`](@ref) — 1:1 rock-salt supercell of two species (NaCl
+  structure), with charges as a per-atom property.
+- [`nacl`](@ref)     — convenience alias for `rocksalt(:Na, :Cl, n)`.
+- [`tip3p_water`](@ref) — cubic box of randomly-placed, randomly-oriented
+  TIP3P water molecules.
+
+These builders are kept in a submodule (rather than top-level) because
+the API may evolve as we learn what consumers want; pin a version if
+you depend on them.
+
+Usage:
+
+```julia
+using AtomsBuilder.Examples
+sys = nacl(2)                     # 64-ion NaCl supercell
+sys = tip3p_water(12.0u"Å")       # ~48-molecule water box
+```
+"""
+module Examples
+
+using AtomsBase: Atom, FlexibleSystem
+using Random: AbstractRNG, default_rng, randn, rand
+using Unitful
+using UnitfulAtomic               # provides u"e_au" (elementary charge)
+using LinearAlgebra: norm
+using StaticArrays: SVector, SMatrix
+
+using ..AtomsBuilder: Vec3, Mat3, _convert_pbc
+
+export rocksalt, nacl, tip3p_water
+
+include("rocksalt.jl")
+include("poisson.jl")
+include("water.jl")
+
+end  # module Examples

--- a/src/examples/poisson.jl
+++ b/src/examples/poisson.jl
@@ -1,0 +1,93 @@
+# --- Bridson Poisson-disk sampler (3-D, periodic) ----------------------
+# All coordinates here are plain `Float64`s in Å (no units) — units are
+# stripped off at the boundary of `tip3p_water` and re-applied to the
+# final `Atom` positions. Keeping internals unitless makes the rejection
+# / distance-check inner loop straightforward and fast.
+
+function _pbc_distance²(a::SVector{3, Float64},
+                        b::SVector{3, Float64}, box::Float64)
+   dx = a - b
+   dx = SVector{3, Float64}(
+      dx[1] - box * round(dx[1] / box),
+      dx[2] - box * round(dx[2] / box),
+      dx[3] - box * round(dx[3] / box),
+   )
+   return sum(abs2, dx)
+end
+
+function _far_from_all(c::SVector{3, Float64},
+                       positions::Vector{SVector{3, Float64}},
+                       d_min²::Float64, box::Float64)
+   @inbounds for p in positions
+      _pbc_distance²(c, p, box) < d_min² && return false
+   end
+   return true
+end
+
+# Phase 1: Bridson — k annulus tries per active point.
+# Phase 2: uniform-rejection fallback to fill any holes Bridson missed.
+# Throws if it can't reach `n_mol`.
+function _poisson_disk_oxygens(box::Float64, n_mol::Int, d_min::Float64,
+                               rng::AbstractRNG;
+                               k::Int = 50,
+                               uniform_fallback_trials::Int = 200_000)
+   d_min²    = d_min * d_min
+   positions = Vector{SVector{3, Float64}}(); sizehint!(positions, n_mol)
+   active    = Int[]                         ; sizehint!(active,    n_mol)
+
+   seed = SVector{3, Float64}(box * rand(rng), box * rand(rng), box * rand(rng))
+   push!(positions, seed); push!(active, 1)
+
+   # Phase 1: Bridson.
+   while !isempty(active) && length(positions) < n_mol
+      idx       = rand(rng, 1:length(active))
+      center_id = active[idx]
+      center    = positions[center_id]
+      placed    = false
+      for _ in 1:k
+         u = SVector{3, Float64}(randn(rng), randn(rng), randn(rng))
+         u = u / norm(u)
+         r = d_min * (1.0 + rand(rng))             # uniform in [d_min, 2·d_min]
+         c = center + r * u
+         c = SVector{3, Float64}(mod(c[1], box), mod(c[2], box), mod(c[3], box))
+         if _far_from_all(c, positions, d_min², box)
+            push!(positions, c)
+            push!(active, length(positions))
+            placed = true
+            break
+         end
+      end
+      if !placed
+         active[idx] = active[end]
+         pop!(active)
+      end
+   end
+
+   # Phase 2: uniform-rejection fallback.
+   trials = 0
+   while length(positions) < n_mol && trials < uniform_fallback_trials
+      trials += 1
+      c = SVector{3, Float64}(box * rand(rng), box * rand(rng), box * rand(rng))
+      if _far_from_all(c, positions, d_min², box)
+         push!(positions, c)
+      end
+   end
+
+   length(positions) == n_mol ||
+      error("Poisson-disk jammed: placed $(length(positions))/$n_mol oxygens " *
+            "(box = $box Å, d_min = $d_min Å, fallback trials = $trials). " *
+            "Lower d_min or n_mol.")
+   return positions
+end
+
+# --- Uniform random rotation on SO(3) via the unit-quaternion method ---
+function _random_rotation_matrix(rng::AbstractRNG)
+   q = SVector{4, Float64}(randn(rng), randn(rng), randn(rng), randn(rng))
+   q = q / norm(q)
+   w, x, y, z = q[1], q[2], q[3], q[4]
+   return SMatrix{3, 3, Float64}(
+      1 - 2*(y*y + z*z),   2*(x*y + z*w),       2*(x*z - y*w),
+      2*(x*y - z*w),       1 - 2*(x*x + z*z),   2*(y*z + x*w),
+      2*(x*z + y*w),       2*(y*z - x*w),       1 - 2*(x*x + y*y),
+   )
+end

--- a/src/examples/rocksalt.jl
+++ b/src/examples/rocksalt.jl
@@ -1,0 +1,94 @@
+# --- rock-salt supercell -----------------------------------------------
+# Reference structure for 1:1 ionic crystals (NaCl, LiF, KCl, MgO, ...).
+# The conventional cell hosts 4 species-A + 4 species-B at the standard
+# fcc / interpenetrating-fcc fractional sites.
+
+const _rocksalt_a_frac = (SVector(0.0, 0.0, 0.0), SVector(0.5, 0.5, 0.0),
+                          SVector(0.5, 0.0, 0.5), SVector(0.0, 0.5, 0.5))
+const _rocksalt_b_frac = (SVector(0.5, 0.0, 0.0), SVector(0.0, 0.5, 0.0),
+                          SVector(0.0, 0.0, 0.5), SVector(0.5, 0.5, 0.5))
+
+# Build an Atom with `charge_label => q` attached as data.
+# Splatting a single Pair into kwargs lets `charge_label` be a runtime Symbol.
+@inline _charged_atom(sym, pos, q, charge_label) =
+   Atom(sym, pos; (charge_label => q,)...)
+
+"""
+    rocksalt(species_a, species_b, n_super;
+             a_lat            = 4.0u"Å",
+             σ                = 0.0u"Å",
+             pbc              = (true, true, true),
+             charge_label::Symbol = :charge,
+             rng::AbstractRNG = default_rng())
+
+Rock-salt (NaCl-structure) supercell of `species_a` and `species_b` in
+a 1:1 ratio. `n_super` is the number of conventional unit cells per
+axis, giving `8 · n_super³` ions in total.
+
+Per-atom charges (`+1 e_au` for `species_a`, `-1 e_au` for `species_b`)
+are attached as a per-atom property with key `charge_label` (default
+`:charge`). `a_lat` is the conventional-cell lattice constant. If
+`σ > 0`, every ion gets an independent isotropic Gaussian Cartesian
+displacement of standard deviation `σ` — `σ ≈ 0.1 Å` roughly mimics a
+300 K thermal sample of NaCl.
+
+Bare-`Real` values for `a_lat` and `σ` are taken to be in Å.
+
+```julia
+sys = rocksalt(:Na, :Cl, 3)                        # 216-ion NaCl
+sys = rocksalt(:Li, :F,  2; a_lat = 4.02u"Å")      # 64-ion LiF
+sys = rocksalt(:Na, :Cl, 2; σ = 0.1u"Å",
+                            rng = MersenneTwister(0))   # thermal
+```
+"""
+function rocksalt(species_a::Symbol, species_b::Symbol, n_super::Integer;
+                  a_lat                = 4.0u"Å",
+                  σ                    = 0.0u"Å",
+                  pbc                  = (true, true, true),
+                  charge_label::Symbol = :charge,
+                  rng::AbstractRNG     = default_rng())
+   a_lat = a_lat isa Real ? a_lat * u"Å" : a_lat
+   σ     = σ     isa Real ? σ     * u"Å" : σ
+
+   TU       = typeof(a_lat)
+   q_a      = +1.0u"e_au"
+   q_b      = -1.0u"e_au"
+   n_atoms  = 8 * n_super^3
+   atoms    = Vector{Atom}(); sizehint!(atoms, n_atoms)
+   thermal  = !iszero(σ)
+
+   @inbounds for i in 0:n_super-1, j in 0:n_super-1, k in 0:n_super-1
+      offset = SVector(Float64(i), Float64(j), Float64(k)) * a_lat
+      for p in _rocksalt_a_frac
+         r0 = p * a_lat + offset
+         δ  = thermal ? σ * SVector(randn(rng), randn(rng), randn(rng)) :
+                         zero(Vec3{TU})
+         push!(atoms, _charged_atom(species_a, r0 + δ, q_a, charge_label))
+      end
+      for p in _rocksalt_b_frac
+         r0 = p * a_lat + offset
+         δ  = thermal ? σ * SVector(randn(rng), randn(rng), randn(rng)) :
+                         zero(Vec3{TU})
+         push!(atoms, _charged_atom(species_b, r0 + δ, q_b, charge_label))
+      end
+   end
+
+   box  = n_super * a_lat
+   cell = Mat3{TU}(box * one(SMatrix{3, 3, Float64}))
+   return FlexibleSystem(atoms;
+                         cell_vectors = tuple([cell[i, :] for i = 1:3]...),
+                         periodicity  = _convert_pbc(pbc))
+end
+
+"""
+    nacl(n_super; kwargs...)
+
+Convenience alias for `rocksalt(:Na, :Cl, n_super; kwargs...)`. Defaults
+match standard rock-salt NaCl (`a_lat = 4.0u"Å"` ≈ ASE reference).
+
+```julia
+sys = nacl(2)              # 64-ion NaCl supercell, perfect lattice
+sys = nacl(3; σ = 0.1)     # 216-ion, 300 K thermal sample
+```
+"""
+nacl(n_super::Integer; kwargs...) = rocksalt(:Na, :Cl, n_super; kwargs...)

--- a/src/examples/water.jl
+++ b/src/examples/water.jl
@@ -1,0 +1,85 @@
+# --- TIP3P-like water box ----------------------------------------------
+# TIP3P (Jorgensen et al., J. Chem. Phys. 79, 926 (1983)): rigid 3-site
+# water model. q_O = -0.834 e_au, q_H = +0.417 e_au, r_OH = 0.9572 Å,
+# ∠HOH = 104.52°.
+
+const _TIP3P_R_OH_VAL = 0.9572                         # Å (bare for math)
+const _TIP3P_THETA    = 104.52 * π / 180
+const _TIP3P_Q_O      = -0.834u"e_au"
+const _TIP3P_Q_H      = +0.417u"e_au"
+
+# H positions in the molecule's local frame (O at origin, C₂ axis ‖ ẑ).
+# Stored as unitless Vec3{Float64} (Å implicit); the rotation matrix R
+# is then unitless 3×3 and `R * H_local` is unitless 3-vector; units are
+# applied when constructing the final Atom positions.
+const _TIP3P_H1_LOCAL = SVector{3, Float64}(
+   _TIP3P_R_OH_VAL * sin(_TIP3P_THETA / 2), 0.0,
+   _TIP3P_R_OH_VAL * cos(_TIP3P_THETA / 2),
+)
+const _TIP3P_H2_LOCAL = SVector{3, Float64}(
+  -_TIP3P_R_OH_VAL * sin(_TIP3P_THETA / 2), 0.0,
+   _TIP3P_R_OH_VAL * cos(_TIP3P_THETA / 2),
+)
+
+"""
+    tip3p_water(box;
+                ρ                = 0.0334u"Å^-3",
+                d_min            = 2.7u"Å",
+                pbc              = (true, true, true),
+                charge_label::Symbol = :charge,
+                rng::AbstractRNG = default_rng())
+
+Cubic-box TIP3P liquid-water configuration. Side length `box`, target
+number density `ρ` ⇒ `n_mol = round(ρ · box³)` molecules. Oxygens are
+placed by Bridson Poisson-disk sampling (min O–O distance `d_min`,
+minimum-image PBC). Each molecule gets a uniformly-random SO(3)
+orientation. Atom order per molecule is `[O, H, H]`.
+
+Per-atom charges (`q_O = -0.834 e_au`, `q_H = +0.417 e_au`) are
+attached as a per-atom property with key `charge_label` (default
+`:charge`).
+
+Bare-`Real` values for `box` and `d_min` are taken to be in Å; bare
+`ρ` is in Å⁻³.
+
+Standard liquid-water values at 300 K: `ρ = 0.0334 mol/Å³` ≈ 1 g/cm³,
+`d_min ≈ 2.7 Å` (just below the first O–O peak in the RDF).
+
+```julia
+sys = tip3p_water(12.0u"Å")                           # ~58 molecules
+sys = tip3p_water(15.0; rng = MersenneTwister(0))     # pinned
+```
+"""
+function tip3p_water(box;
+                     ρ                    = 0.0334u"Å^-3",
+                     d_min                = 2.7u"Å",
+                     pbc                  = (true, true, true),
+                     charge_label::Symbol = :charge,
+                     rng::AbstractRNG     = default_rng())
+   box   = box   isa Real ? box   * u"Å"    : box
+   ρ     = ρ     isa Real ? ρ     * u"Å^-3" : ρ
+   d_min = d_min isa Real ? d_min * u"Å"    : d_min
+
+   box_val   = ustrip(u"Å",    box)
+   d_min_val = ustrip(u"Å",    d_min)
+   ρ_val     = ustrip(u"Å^-3", ρ)
+
+   n_mol     = round(Int, ρ_val * box_val^3)
+   O_centres = _poisson_disk_oxygens(box_val, n_mol, d_min_val, rng)
+
+   atoms = Vector{Atom}(); sizehint!(atoms, 3 * n_mol)
+   for O in O_centres
+      R  = _random_rotation_matrix(rng)
+      H1 = O + R * _TIP3P_H1_LOCAL
+      H2 = O + R * _TIP3P_H2_LOCAL
+      push!(atoms, _charged_atom(:O, O  * u"Å", _TIP3P_Q_O, charge_label))
+      push!(atoms, _charged_atom(:H, H1 * u"Å", _TIP3P_Q_H, charge_label))
+      push!(atoms, _charged_atom(:H, H2 * u"Å", _TIP3P_Q_H, charge_label))
+   end
+
+   TU   = typeof(box)
+   cell = Mat3{TU}(box * one(SMatrix{3, 3, Float64}))
+   return FlexibleSystem(atoms;
+                         cell_vectors = tuple([cell[i, :] for i = 1:3]...),
+                         periodicity  = _convert_pbc(pbc))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using Test
     # Write your tests here.
     @testset "bulk" begin include("test_bulk.jl"); end
     @testset "utils" begin include("test_utils.jl"); end
+    @testset "Examples — rocksalt" begin include("test_examples_rocksalt.jl"); end
+    @testset "Examples — water"    begin include("test_examples_water.jl");    end
     include("test_pubchem.jl")
 end
 

--- a/test/test_examples_rocksalt.jl
+++ b/test/test_examples_rocksalt.jl
@@ -25,7 +25,7 @@ using LinearAlgebra: norm
    end
 
    # All 64 atoms carry a `:charge` per-atom datum, ±1 e_au, summing to zero.
-   charges = [a.data[:charge] for a in sys]
+   charges = [a[:charge] for a in sys]
    @test all(c -> c == +1.0u"e_au" || c == -1.0u"e_au", charges)
    @test sum(charges) ≈ 0.0u"e_au"
    @test count(==( +1.0u"e_au"), charges) == 32
@@ -45,9 +45,9 @@ end
    @test length(sys) == 8
    # Custom kwarg name flows through.
    for a in sys
-      @test a.data[:q] == +1.0u"e_au" || a.data[:q] == -1.0u"e_au"
+      @test a[:q] == +1.0u"e_au" || a[:q] == -1.0u"e_au"
    end
-   @test sum(a.data[:q] for a in sys) ≈ 0.0u"e_au"
+   @test sum(a[:q] for a in sys) ≈ 0.0u"e_au"
 
    # Cubic box of side 1 · 4.02 Å.
    cv = cell_vectors(sys)
@@ -71,7 +71,7 @@ end
       @test norm(position(sys, i) - position(sys0, i)) > 0.0u"Å"
    end
    # Charges unchanged.
-   @test sum(a.data[:charge] for a in sys) ≈ 0.0u"e_au"
+   @test sum(a[:charge] for a in sys) ≈ 0.0u"e_au"
 end
 
 @testset "rocksalt — rng reproducibility with σ > 0" begin

--- a/test/test_examples_rocksalt.jl
+++ b/test/test_examples_rocksalt.jl
@@ -1,0 +1,91 @@
+
+using AtomsBuilder
+using AtomsBuilder.Examples
+using Test, AtomsBase, Unitful, UnitfulAtomic, Random
+using StaticArrays: SVector
+using LinearAlgebra: norm
+
+##
+
+@testset "rocksalt — size, cell, pbc, charges" begin
+   sys = nacl(2)
+
+   @test length(sys) == 8 * 2^3
+   @test periodicity(sys) == (true, true, true)
+
+   cv = cell_vectors(sys)
+   @test length(cv) == 3
+   # Cubic box of side 2 · a_lat = 8 Å (default a_lat = 4 Å).
+   for (k, v) in enumerate(cv)
+      @test ustrip(u"Å", v[k]) ≈ 8.0
+      for (j, vj) in enumerate(v)
+         j == k && continue
+         @test ustrip(u"Å", vj) ≈ 0.0 atol = 1e-12
+      end
+   end
+
+   # All 64 atoms carry a `:charge` per-atom datum, ±1 e_au, summing to zero.
+   charges = [a.data[:charge] for a in sys]
+   @test all(c -> c == +1.0u"e_au" || c == -1.0u"e_au", charges)
+   @test sum(charges) ≈ 0.0u"e_au"
+   @test count(==( +1.0u"e_au"), charges) == 32
+   @test count(==( -1.0u"e_au"), charges) == 32
+
+   # Species: 4×4 of each per conventional cell, ×8 cells = 32 each.
+   zs = atomic_number(sys, :)
+   z_Na = AtomsBuilder.Chemistry.atomic_number(:Na)
+   z_Cl = AtomsBuilder.Chemistry.atomic_number(:Cl)
+   @test count(==(z_Na), zs) == 32
+   @test count(==(z_Cl), zs) == 32
+end
+
+@testset "rocksalt — generic species + custom charge_label" begin
+   sys = rocksalt(:Li, :F, 1; a_lat = 4.02u"Å", charge_label = :q)
+
+   @test length(sys) == 8
+   # Custom kwarg name flows through.
+   for a in sys
+      @test a.data[:q] == +1.0u"e_au" || a.data[:q] == -1.0u"e_au"
+   end
+   @test sum(a.data[:q] for a in sys) ≈ 0.0u"e_au"
+
+   # Cubic box of side 1 · 4.02 Å.
+   cv = cell_vectors(sys)
+   @test ustrip(u"Å", cv[1][1]) ≈ 4.02
+end
+
+@testset "rocksalt — σ = 0 is deterministic" begin
+   sys_a = nacl(2; rng = MersenneTwister(0))
+   sys_b = nacl(2; rng = MersenneTwister(123))
+   # No randomness when σ = 0 ⇒ positions identical regardless of seed.
+   @test all(position(sys_a, :) .== position(sys_b, :))
+end
+
+@testset "rocksalt — σ > 0 displaces but preserves count and charges" begin
+   sys0 = nacl(2)
+   sys  = nacl(2; σ = 0.1u"Å", rng = MersenneTwister(42))
+
+   @test length(sys) == length(sys0)
+   # All atoms move by more than 0 (with probability 1 for a Gaussian).
+   for i in 1:length(sys)
+      @test norm(position(sys, i) - position(sys0, i)) > 0.0u"Å"
+   end
+   # Charges unchanged.
+   @test sum(a.data[:charge] for a in sys) ≈ 0.0u"e_au"
+end
+
+@testset "rocksalt — rng reproducibility with σ > 0" begin
+   sys_a = nacl(2; σ = 0.1, rng = MersenneTwister(7))
+   sys_b = nacl(2; σ = 0.1, rng = MersenneTwister(7))
+   @test all(position(sys_a, :) .== position(sys_b, :))
+
+   sys_c = nacl(2; σ = 0.1, rng = MersenneTwister(8))
+   @test position(sys_a, 1) != position(sys_c, 1)
+end
+
+@testset "rocksalt — bare-Real kwargs interpreted as Å" begin
+   sys_q = nacl(1; a_lat = 4.0u"Å")
+   sys_r = nacl(1; a_lat = 4.0)
+   @test position(sys_q, :) == position(sys_r, :)
+   @test cell_vectors(sys_q) == cell_vectors(sys_r)
+end

--- a/test/test_examples_water.jl
+++ b/test/test_examples_water.jl
@@ -33,7 +33,7 @@ end
 
 @testset "tip3p_water — charges (TIP3P values, neutral molecules)" begin
    sys = tip3p_water(12.0u"Å"; rng = MersenneTwister(0))
-   charges = [a.data[:charge] for a in sys]
+   charges = [a[:charge] for a in sys]
    @test charges[1:3:end] == fill(-0.834u"e_au", length(sys) ÷ 3)
    @test charges[2:3:end] == fill(+0.417u"e_au", length(sys) ÷ 3)
    @test charges[3:3:end] == fill(+0.417u"e_au", length(sys) ÷ 3)
@@ -92,6 +92,6 @@ end
 
 @testset "tip3p_water — custom charge_label" begin
    sys = tip3p_water(10.0u"Å"; charge_label = :q, rng = MersenneTwister(0))
-   @test sys[1].data[:q] == -0.834u"e_au"
-   @test sys[2].data[:q] == +0.417u"e_au"
+   @test sys[1][:q] == -0.834u"e_au"
+   @test sys[2][:q] == +0.417u"e_au"
 end

--- a/test/test_examples_water.jl
+++ b/test/test_examples_water.jl
@@ -1,0 +1,97 @@
+
+using AtomsBuilder
+using AtomsBuilder.Examples
+using Test, AtomsBase, Unitful, UnitfulAtomic, Random
+using LinearAlgebra: norm, ⋅
+
+##
+
+@testset "tip3p_water — size, density, structure" begin
+   box  = 12.0u"Å"
+   ρ    = 0.0334u"Å^-3"
+   sys  = tip3p_water(box; ρ = ρ, rng = MersenneTwister(0))
+
+   n_mol = round(Int, ustrip(u"Å^-3", ρ) * ustrip(u"Å", box)^3)
+   @test length(sys) == 3 * n_mol
+   @test length(sys) % 3 == 0
+   @test periodicity(sys) == (true, true, true)
+
+   # Cubic cell of side `box`.
+   cv = cell_vectors(sys)
+   for (k, v) in enumerate(cv)
+      @test ustrip(u"Å", v[k]) ≈ ustrip(u"Å", box)
+   end
+
+   # Atom order is [O, H, H, O, H, H, ...].
+   zs = atomic_number(sys, :)
+   z_O = AtomsBuilder.Chemistry.atomic_number(:O)
+   z_H = AtomsBuilder.Chemistry.atomic_number(:H)
+   @test zs[1:3:end] == fill(z_O, n_mol)
+   @test zs[2:3:end] == fill(z_H, n_mol)
+   @test zs[3:3:end] == fill(z_H, n_mol)
+end
+
+@testset "tip3p_water — charges (TIP3P values, neutral molecules)" begin
+   sys = tip3p_water(12.0u"Å"; rng = MersenneTwister(0))
+   charges = [a.data[:charge] for a in sys]
+   @test charges[1:3:end] == fill(-0.834u"e_au", length(sys) ÷ 3)
+   @test charges[2:3:end] == fill(+0.417u"e_au", length(sys) ÷ 3)
+   @test charges[3:3:end] == fill(+0.417u"e_au", length(sys) ÷ 3)
+   # Each molecule is neutral to high precision; total exactly zero by symmetry.
+   total = sum(charges)
+   @test abs(ustrip(u"e_au", total)) < 1e-12
+end
+
+@testset "tip3p_water — O–H bond length and H–O–H angle" begin
+   sys = tip3p_water(12.0u"Å"; rng = MersenneTwister(0))
+   X   = position(sys, :)
+   n_mol = length(sys) ÷ 3
+   for m in 1:n_mol
+      O  = X[3m - 2]
+      H1 = X[3m - 1]
+      H2 = X[3m    ]
+      rOH1 = norm(H1 - O)
+      rOH2 = norm(H2 - O)
+      @test ustrip(u"Å", rOH1) ≈ 0.9572 atol = 1e-10
+      @test ustrip(u"Å", rOH2) ≈ 0.9572 atol = 1e-10
+      cosθ = (H1 - O) ⋅ (H2 - O) / (rOH1 * rOH2)
+      @test acos(cosθ) ≈ 104.52 * π / 180 atol = 1e-10
+   end
+end
+
+@testset "tip3p_water — Poisson-disk respects d_min (minimum-image PBC)" begin
+   box   = 15.0u"Å"
+   d_min = 2.7u"Å"
+   sys   = tip3p_water(box; d_min = d_min, rng = MersenneTwister(0))
+   X     = position(sys, :)
+   # Oxygens are at positions 1, 4, 7, ...
+   O_idx = 1:3:length(sys)
+   bv    = ustrip(u"Å", box)
+   for (a_idx, i) in enumerate(O_idx), j in O_idx[a_idx+1:end]
+      dx_unitful = X[i] - X[j]
+      # minimum-image
+      dx = [ustrip(u"Å", dx_unitful[k]) - bv * round(ustrip(u"Å", dx_unitful[k]) / bv) for k in 1:3]
+      @test sqrt(sum(abs2, dx)) ≥ ustrip(u"Å", d_min) - 1e-9
+   end
+end
+
+@testset "tip3p_water — rng reproducibility" begin
+   a = tip3p_water(10.0u"Å"; rng = MersenneTwister(11))
+   b = tip3p_water(10.0u"Å"; rng = MersenneTwister(11))
+   @test position(a, :) == position(b, :)
+
+   c = tip3p_water(10.0u"Å"; rng = MersenneTwister(12))
+   @test position(a, :) != position(c, :)
+end
+
+@testset "tip3p_water — bare-Real arguments interpreted as Å" begin
+   a = tip3p_water(10.0u"Å"; rng = MersenneTwister(5))
+   b = tip3p_water(10.0;     rng = MersenneTwister(5))
+   @test position(a, :) == position(b, :)
+end
+
+@testset "tip3p_water — custom charge_label" begin
+   sys = tip3p_water(10.0u"Å"; charge_label = :q, rng = MersenneTwister(0))
+   @test sys[1].data[:q] == -0.834u"e_au"
+   @test sys[2].data[:q] == +0.417u"e_au"
+end


### PR DESCRIPTION
Notes: 
- this was 99% vibe-coded, the code is non-critical, but maybe this needs to be documented
- The spirit of this PR is how I thought about AtomsBuilder, if we have any structure in some project that could be useful elsewhere, we can move it in here
- Maybe a submodule `Examples` is not the right way to include this, I just didn't have a better idea. 
- CC @mfherbst would you be willing to take a brief high-level look at this and see if you spot a problem?

TODO: 
- [x] fix docs to include new docstrings

## Summary

Adds a new `AtomsBuilder.Examples` submodule with three fixture-system builders that downstream packages can use for testing, benchmarking, and tuning:

- `rocksalt(species_a, species_b, n_super; …)` — 1:1 rock-salt (NaCl-structure) supercell of any two species, with `±1 e_au` charges attached as a per-atom property.
- `nacl(n_super; …)` — convenience alias for `rocksalt(:Na, :Cl, n_super; …)`.
- `tip3p_water(box; …)` — cubic-box TIP3P liquid-water configuration. Oxygens placed by Bridson Poisson-disk sampling (with a uniform-rejection fallback for jamming); each molecule given a uniformly-random SO(3) orientation. Charges `q_O = -0.834 e_au`, `q_H = +0.417 e_au`.

Both kinds of system are returned as `FlexibleSystem`s. All builders accept either `Unitful.Quantity` arguments or bare `Real` (taken as Å / Å⁻³).

## Motivation

These builders were originally drafted inside [MultilevelSummation.jl](https://github.com/ACEsuit/MultilevelSummation.jl/blob/main/src/tune/systems.jl) as staging code; the docstrings there already announce the intended move upstream. They're useful as common fixtures for any package working on charged systems (Ewald, MSM, P3M, PPPM, …), so they belong somewhere shared. `Examples` was chosen to signal "small, focused, illustrative builders" rather than "API churn expected".

## API

```julia
using AtomsBuilder.Examples, Unitful, UnitfulAtomic, Random

# 64-ion NaCl supercell, perfect lattice
sys = nacl(2)

# 216-ion NaCl, ~300 K thermal sample (σ = 0.1 Å Gaussian displacements)
sys = nacl(3; σ = 0.1u"Å", rng = MersenneTwister(0))

# Generic 1:1 salt with a custom lattice constant
sys = rocksalt(:Li, :F, 2; a_lat = 4.02u"Å")

# ~58-molecule water box at 1 g/cm³, default d_min = 2.7 Å
sys = tip3p_water(12.0u"Å")
```

### Charge convention

Charges are stored on each `Atom` as per-atom data under the kwarg `charge_label` (default `:charge`). Extract via `atom.data[:charge]`:

```julia
sys = nacl(2)
sum(a.data[:charge] for a in sys)   # 0 e_au

# Use a different key
sys = nacl(2; charge_label = :q)
sys[1].data[:q]                     # ±1 e_au
```

The `charge_label` knob is there because AtomsBase doesn't yet specify a canonical accessor for atomic charges — downstream consumers that follow a different convention can rename without monkey-patching. Happy to change the default in review if there's a preference.

## Dependencies

Adds one new dep: [`UnitfulAtomic`](https://github.com/sostock/UnitfulAtomic.jl) for `u"e_au"` (the elementary charge). It's a tiny package; only pulls in `Unitful`, which is already a dep.

## Limitations / scope

Things this PR explicitly does **not** try to do — happy to expand any of these on request or in follow-ups:

- **Stoichiometry**: `rocksalt` is 1:1 only. Generalisation to CaF₂-, perovskite-, spinel-style ratios would mean a different function (`fluorite`, `perovskite`, …) rather than overloading this one.
- **Box shape**: `tip3p_water` is cubic only. Rectangular / triclinic boxes are mechanically straightforward but would change the API (probably a `cell::SMatrix` kwarg instead of a scalar `box`).
- **Poisson-disk jamming**: the Bridson sampler + uniform-rejection fallback handles ρ ≈ 0.0334 Å⁻³ at d_min = 2.7 Å reliably, but throws if it can't reach `n_mol` (e.g. d_min too large for the requested density). This is intentional — silently dropping molecules would be worse — but the error message currently just suggests lowering `d_min` or `n_mol`.
- **Thermal sampling for rocksalt**: σ-displacements are i.i.d. isotropic Gaussian, not from a real Boltzmann distribution / MD trajectory. Fine as a noise injection ("not a perfect lattice"); not fine as a thermodynamically-correct sample.
- **Water orientations**: uniform on SO(3), so the initial config has *no* H-bond network. Suitable for testing long-range solvers where the precise structure doesn't matter, not for production MD without equilibration.
- **No velocities or masses set explicitly**: builders use the AtomsBase `Atom(species, position; …)` defaults, so masses come from the AtomsBase species table and velocities default to zero. If you need a thermal velocity distribution, set it after construction.
- **Charge accessor**: as noted above, no AtomsBase-blessed accessor for atomic charges — consumers reach into `atom.data[:charge]` directly. Whenever AtomsBase grows a `charge(atom)` (or similar) function, that would be the natural upgrade path. => is this true? double-checking now ... 

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` locally → all 6673 tests pass (existing `bulk`/`utils`/`pubchem` + new `Examples` testsets).
- [x] Coverage in `test/test_examples_rocksalt.jl` and `test/test_examples_water.jl`:
  - size, cell, pbc, charge totals (± per species count)
  - custom `charge_label` flows through
  - `σ = 0` deterministic (independent of rng seed)
  - `σ > 0` reproducible under the same seed, divergent under different seeds
  - bare-`Real` kwargs interpreted as Å / Å⁻³ — identity with unitful equivalents
  - O–H bond length (0.9572 Å) and H–O–H angle (104.52°) preserved by SO(3) sampling
  - Poisson-disk respects `d_min` under minimum-image PBC
- [x] Version bumped 0.2.3 → 0.2.4 (patch — no breaking changes).
